### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/float64/mat4/mat4.go
+++ b/float64/mat4/mat4.go
@@ -156,7 +156,7 @@ func (mat *T) MulVec4(v *vec4.T) vec4.T {
 	}
 }
 
-// MulVec4 multiplies v with mat and saves the result in v.
+// TransformVec4 multiplies v with mat and saves the result in v.
 func (mat *T) TransformVec4(v *vec4.T) {
 	// Use intermediate variables to not alter further computations.
 	x := mat[0][0]*v[0] + mat[1][0]*v[1] + mat[2][0]*v[2] + mat[3][0]*v[3]

--- a/mat4/mat4.go
+++ b/mat4/mat4.go
@@ -187,7 +187,7 @@ func (mat *T) MulVec4(v *vec4.T) vec4.T {
 	}
 }
 
-// MulVec4 multiplies v with mat and saves the result in v.
+// TransformVec4 multiplies v with mat and saves the result in v.
 func (mat *T) TransformVec4(v *vec4.T) {
 	// Use intermediate variables to not alter further computations.
 	x := mat[0][0]*v[0] + mat[1][0]*v[1] + mat[2][0]*v[2] + mat[3][0]*v[3]


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?