### PR TITLE
Update quaternion AxisAngle calculation

### DIFF
--- a/float64/quaternion/quaternion.go
+++ b/float64/quaternion/quaternion.go
@@ -76,7 +76,7 @@ func (quat *T) String() string {
 	return fmt.Sprint(quat[0], quat[1], quat[2], quat[3])
 }
 
-// AxisAngle extracts the rotation from a normalize quaternion in the form of an axis and a rotation angle.
+// AxisAngle extracts the rotation from a normalized quaternion in the form of an axis and a rotation angle.
 func (quat *T) AxisAngle() (axis vec3.T, angle float64) {
 	cos := quat[3]
 	sin := math.Sqrt(1 - cos*cos)

--- a/float64/quaternion/quaternion.go
+++ b/float64/quaternion/quaternion.go
@@ -80,7 +80,7 @@ func (quat *T) String() string {
 func (quat *T) AxisAngle() (axis vec3.T, angle float64) {
 	cos := quat[3]
 	sin := math.Sqrt(1 - cos*cos)
-	angle = math.Acos(cos)
+	angle = math.Acos(cos) * 2
 
 	var ooSin float64
 	if math.Abs(sin) < 0.0005 {

--- a/float64/quaternion/quaternion.go
+++ b/float64/quaternion/quaternion.go
@@ -76,7 +76,7 @@ func (quat *T) String() string {
 	return fmt.Sprint(quat[0], quat[1], quat[2], quat[3])
 }
 
-// AxisAngle extracts the rotation in form of an axis and a rotation angle.
+// AxisAngle extracts the rotation from a normalize quaternion in the form of an axis and a rotation angle.
 func (quat *T) AxisAngle() (axis vec3.T, angle float64) {
 	cos := quat[3]
 	sin := math.Sqrt(1 - cos*cos)


### PR DESCRIPTION
Based on what I am reading here: https://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToAngle/index.htm, I believe angle should equal 2 * Acos(w). Given a quaternion where w = 0.8775825618903728, and v = (0, 0, 0.479425538604203), I would expect this to return an angle close to ~1. Instead I get ~0.5.