### PR TITLE
Fixed bug in Invert mat3, added invert to mat2

### DIFF
--- a/float64/mat2/mat2.go
+++ b/float64/mat2/mat2.go
@@ -2,6 +2,7 @@
 package mat2
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/ungerik/go3d/float64/generic"
@@ -10,7 +11,10 @@ import (
 
 var (
 	// Zero holds a zero matrix.
-	Zero = T{}
+	Zero = T{
+		vec2.T{0, 0},
+		vec2.T{0, 0},
+	}
 
 	// Ident holds an ident matrix.
 	Ident = T{
@@ -77,6 +81,18 @@ func (mat *T) Slice() []float64 {
 }
 
 // Get returns one element of the matrix.
+// Matrices are defined by (two) column vectors.
+//
+// Note that this function use the opposite reference order of rows and columns to the mathematical matrix indexing.
+//
+// A value in this matrix is referenced by <col><row> where both row and column is in the range [0..1].
+// This notation and range reflects the underlying representation.
+//
+// A value in a matrix A is mathematically referenced by A<row><col>
+// where both row and column is in the range [1..2].
+// (It is really the lower case 'a' followed by <row><col> but this documentation syntax is somewhat limited.)
+//
+// matrixA.Get(0, 1) == matrixA[0][1] ( == A21 in mathematical indexing)
 func (mat *T) Get(col, row int) float64 {
 	return mat[col][row]
 }
@@ -143,10 +159,46 @@ func (mat *T) Determinant() float64 {
 	return mat[0][0]*mat[1][1] - mat[1][0]*mat[0][1]
 }
 
+// PracticallyEquals compares two matrices if they are equal with each other within a delta tolerance.
+func (mat *T) PracticallyEquals(matrix *T, allowedDelta float64) bool {
+	return mat[0].PracticallyEquals(&matrix[0], allowedDelta) &&
+		mat[1].PracticallyEquals(&matrix[1], allowedDelta)
+}
+
 // Transpose transposes the matrix.
 func (mat *T) Transpose() *T {
-	temp := mat[0][1]
-	mat[0][1] = mat[1][0]
-	mat[1][0] = temp
+	mat[0][1], mat[1][0] = mat[1][0], mat[0][1]
 	return mat
+}
+
+// Transposed returns a transposed copy the matrix.
+func (mat *T) Transposed() T {
+	result := *mat
+	result.Transpose()
+	return result
+}
+
+// Invert inverts the given matrix. Destructive operation.
+// Does not check if matrix is singular and may lead to strange results!
+func (mat *T) Invert() (*T, error) {
+	determinant := mat.Determinant()
+	if determinant == 0 {
+		return &Zero, errors.New("can not create inverted matrix as determinant is 0")
+	}
+
+	invDet := 1.0 / determinant
+
+	mat[0][0], mat[1][1] = invDet*mat[1][1], invDet*mat[0][0]
+	mat[0][1] = -invDet * mat[0][1]
+	mat[1][0] = -invDet * mat[1][0]
+
+	return mat, nil
+}
+
+// Inverted inverts a copy of the given matrix.
+// Does not check if matrix is singular and may lead to strange results!
+func (mat *T) Inverted() (T, error) {
+	result := *mat
+	_, err := result.Invert()
+	return result, err
 }

--- a/float64/mat2/mat2_test.go
+++ b/float64/mat2/mat2_test.go
@@ -1,0 +1,154 @@
+package mat2
+
+import (
+	"math"
+	"testing"
+
+	"github.com/ungerik/go3d/float64/vec2"
+)
+
+const EPSILON = 0.0001
+
+// Some matrices used in multiple tests.
+var (
+	invertableMatrix1    = T{vec2.T{4, -2}, vec2.T{8, -3}}
+	invertedMatrix1      = T{vec2.T{-3.0 / 4.0, 1.0 / 2.0}, vec2.T{-2, 1}}
+	nonInvertableMatrix1 = T{vec2.T{1, 1}, vec2.T{1, 1}}
+	nonInvertableMatrix2 = T{vec2.T{2, 0}, vec2.T{1, 0}}
+
+	testMatrix1 = T{
+		vec2.T{0.38016528, -0.0661157},
+		vec2.T{-0.19834709, 0.33884296},
+	}
+
+	testMatrix2 = T{
+		vec2.T{23, -4},
+		vec2.T{-12, 20.5},
+	}
+
+	row123Changed, _ = Parse("3 1   2 5")
+)
+
+func TestT_Transposed(t *testing.T) {
+	matrix := T{
+		vec2.T{1, 2},
+		vec2.T{3, 4},
+	}
+	expectedMatrix := T{
+		vec2.T{1, 3},
+		vec2.T{2, 4},
+	}
+
+	transposedMatrix := matrix.Transposed()
+
+	if transposedMatrix != expectedMatrix {
+		t.Errorf("matrix trasnposed wrong: %v --> %v", matrix, transposedMatrix)
+	}
+}
+
+func TestT_Transpose(t *testing.T) {
+	matrix := T{
+		vec2.T{10, 20},
+		vec2.T{30, 40},
+	}
+
+	expectedMatrix := T{
+		vec2.T{10, 30},
+		vec2.T{20, 40},
+	}
+
+	transposedMatrix := matrix
+	transposedMatrix.Transpose()
+
+	if transposedMatrix != expectedMatrix {
+		t.Errorf("matrix transposed wrong: %v --> %v", matrix, transposedMatrix)
+	}
+}
+
+func TestDeterminant_2(t *testing.T) {
+	detTwo := Ident
+	detTwo[0][0] = 2
+	if det := detTwo.Determinant(); det != (2*1 - 0*0) {
+		t.Errorf("Wrong determinant: %f", det)
+	}
+}
+
+func TestDeterminant_3(t *testing.T) {
+	scale2 := Ident.Scaled(2)
+	if det := scale2.Determinant(); det != (2*2 - 0*0) {
+		t.Errorf("Wrong determinant: %f", det)
+	}
+}
+
+func TestDeterminant_4(t *testing.T) {
+	row1changed, _ := Parse("3 0   2 2")
+	if det := row1changed.Determinant(); det != (3*2 - 0*2) {
+		t.Errorf("Wrong determinant: %f", det)
+	}
+}
+
+func TestDeterminant_5(t *testing.T) {
+	row12changed, _ := Parse("3 1   2 5")
+	if det := row12changed.Determinant(); det != (3*5 - 1*2) {
+		t.Errorf("Wrong determinant: %f", det)
+	}
+}
+
+func TestDeterminant_7(t *testing.T) {
+	randomMatrix, err := Parse("0.43685 0.81673   0.16600 0.40608")
+	randomMatrix.Transpose()
+	if err != nil {
+		t.Errorf("Could not parse random matrix: %v", err)
+	}
+	if det := randomMatrix.Determinant(); PracticallyEquals(det, 0.0418189) {
+		t.Errorf("Wrong determinant for random sub 3x3 matrix: %f", det)
+	}
+}
+
+func PracticallyEquals(value1 float64, value2 float64) bool {
+	return math.Abs(value1-value2) > EPSILON
+}
+
+func TestDeterminant_6(t *testing.T) {
+	row123changed := row123Changed
+	if det := row123changed.Determinant(); det != (3*5 - 2*1) {
+		t.Errorf("Wrong determinant for 3x3 matrix: %f", det)
+	}
+}
+
+func TestDeterminant_1(t *testing.T) {
+	detId := Ident.Determinant()
+	if detId != 1 {
+		t.Errorf("Wrong determinant for identity matrix: %f", detId)
+	}
+}
+
+func TestInvert_ok(t *testing.T) {
+	inv := invertableMatrix1
+	_, err := inv.Invert()
+
+	if err != nil {
+		t.Error("Inverse not computed correctly", err)
+	}
+
+	invExpected := invertedMatrix1
+	if inv != invExpected {
+		t.Errorf("Inverse not computed correctly: %#v", inv)
+	}
+}
+
+func TestInvert_nok_1(t *testing.T) {
+	inv := nonInvertableMatrix1
+	_, err := inv.Inverted()
+	if err == nil {
+		t.Error("Inverse should not be possible", err)
+	}
+}
+
+func TestInvert_nok_2(t *testing.T) {
+	inv := nonInvertableMatrix2
+	_, err := inv.Inverted()
+	if err == nil {
+		t.Error("Inverse should not be possible", err)
+	}
+}

--- a/float64/mat3/mat3.go
+++ b/float64/mat3/mat3.go
@@ -87,6 +87,18 @@ func (mat *T) Slice() []float64 {
 }
 
 // Get returns one element of the matrix.
+// Matrices are defined by (three) column vectors.
+//
+// Note that this function use the opposite reference order of rows and columns to the mathematical matrix indexing.
+//
+// A value in this matrix is referenced by <col><row> where both row and column is in the range [0..2].
+// This notation and range reflects the underlying representation.
+//
+// A value in a matrix A is mathematically referenced by A<row><col>
+// where both row and column is in the range [1..3].
+// (It is really the lower case 'a' followed by <row><col> but this documentation syntax is somewhat limited.)
+//
+// matrixA.Get(1, 2) == matrixA[1][2] ( == A32 in mathematical indexing)
 func (mat *T) Get(col, row int) float64 {
 	return mat[col][row]
 }
@@ -181,11 +193,18 @@ func (mat *T) AssignMat2x2(m *mat2.T) *T {
 
 // Mul multiplies every element by f and returns mat.
 func (mat *T) Mul(f float64) *T {
-	for i, col := range mat {
-		for j := range col {
-			mat[i][j] *= f
-		}
-	}
+	mat[0][0] *= f
+	mat[0][1] *= f
+	mat[0][2] *= f
+
+	mat[1][0] *= f
+	mat[1][1] *= f
+	mat[1][2] *= f
+
+	mat[2][0] *= f
+	mat[2][1] *= f
+	mat[2][2] *= f
+
 	return mat
 }
 
@@ -392,31 +411,45 @@ func (mat *T) IsReflective() bool {
 	return mat.Determinant() < 0
 }
 
-func swap(a, b *float64) {
-	temp := *a
-	*a = *b
-	*b = temp
+// PracticallyEquals compares two matrices if they are equal with each other within a delta tolerance.
+func (mat *T) PracticallyEquals(matrix *T, allowedDelta float64) bool {
+	return mat[0].PracticallyEquals(&matrix[0], allowedDelta) &&
+		mat[1].PracticallyEquals(&matrix[1], allowedDelta) &&
+		mat[2].PracticallyEquals(&matrix[2], allowedDelta)
 }
 
 // Transpose transposes the matrix.
 func (mat *T) Transpose() *T {
-	swap(&mat[1][0], &mat[0][1])
-	swap(&mat[2][0], &mat[0][2])
-	swap(&mat[2][1], &mat[1][2])
+	mat[1][0], mat[0][1] = mat[0][1], mat[1][0]
+	mat[2][0], mat[0][2] = mat[0][2], mat[2][0]
+	mat[2][1], mat[1][2] = mat[1][2], mat[2][1]
 	return mat
 }
 
+// Transposed returns a transposed copy the matrix.
+func (mat *T) Transposed() T {
+	result := *mat
+	result.Transpose()
+	return result
+}
+
 // Adjugate computes the adjugate of this matrix and returns mat
-func (mat *T) Adjugate() *T {
-	matOrig := *mat
-	for i := 0; i < 3; i++ {
-		for j := 0; j < 3; j++ {
-			// -1 for odd i+j, 1 for even i+j
-			sign := float64(((i+j)%2)*-2 + 1)
-			mat[i][j] = matOrig.maskedBlock(i, j).Determinant() * sign
-		}
-	}
-	return mat.Transpose()
+func (matrix *T) Adjugate() *T {
+	mat := *matrix
+
+	matrix[0][0] = +(mat[1][1]*mat[2][2] - mat[1][2]*mat[2][1])
+	matrix[0][1] = -(mat[0][1]*mat[2][2] - mat[0][2]*mat[2][1])
+	matrix[0][2] = +(mat[0][1]*mat[1][2] - mat[0][2]*mat[1][1])
+
+	matrix[1][0] = -(mat[1][0]*mat[2][2] - mat[1][2]*mat[2][0])
+	matrix[1][1] = +(mat[0][0]*mat[2][2] - mat[0][2]*mat[2][0])
+	matrix[1][2] = -(mat[0][0]*mat[1][2] - mat[0][2]*mat[1][0])
+
+	matrix[2][0] = +(mat[1][0]*mat[2][1] - mat[1][1]*mat[2][0])
+	matrix[2][1] = -(mat[0][0]*mat[2][1] - mat[0][1]*mat[2][0])
+	matrix[2][2] = +(mat[0][0]*mat[1][1] - mat[0][1]*mat[1][0])
+
+	return matrix
 }
 
 // Adjugated returns an adjugated copy of the matrix.
@@ -456,7 +489,7 @@ func (mat *T) Invert() (*T, error) {
 	}
 
 	mat.Adjugate()
-	mat.Scale(1 / initialDet)
+	mat.Mul(1.0 / initialDet)
 	return mat, nil
 }
 

--- a/float64/mat3/mat3_test.go
+++ b/float64/mat3/mat3_test.go
@@ -33,6 +33,70 @@ var (
 	row123Changed, _ = Parse("3 1 0.5   2 5 2   1 6 7")
 )
 
+func Test_ColsAndRows(t *testing.T) {
+	A := testMatrix2
+
+	a11 := A.Get(0, 0)
+	a21 := A.Get(0, 1)
+	a31 := A.Get(0, 2)
+
+	a12 := A.Get(1, 0)
+	a22 := A.Get(1, 1)
+	a32 := A.Get(1, 2)
+
+	a13 := A.Get(2, 0)
+	a23 := A.Get(2, 1)
+	a33 := A.Get(2, 2)
+
+	correctReference := a11 == 23 && a21 == -4 && a31 == -0.5 &&
+		a12 == -12 && a22 == 20.5 && a32 == -5 &&
+		a13 == 7 && a23 == -17 && a33 == 13
+
+	if !correctReference {
+		t.Errorf("matrix ill referenced")
+	}
+}
+
+func TestT_Transposed(t *testing.T) {
+	matrix := T{
+		vec3.T{1, 2, 3},
+		vec3.T{4, 5, 6},
+		vec3.T{7, 8, 9},
+	}
+	expectedMatrix := T{
+		vec3.T{1, 4, 7},
+		vec3.T{2, 5, 8},
+		vec3.T{3, 6, 9},
+	}
+
+	transposedMatrix := matrix.Transposed()
+
+	if transposedMatrix != expectedMatrix {
+		t.Errorf("matrix transposed wrong: %v --> %v", matrix, transposedMatrix)
+	}
+}
+
+func TestT_Transpose(t *testing.T) {
+	matrix := T{
+		vec3.T{10, 20, 30},
+		vec3.T{40, 50, 60},
+		vec3.T{70, 80, 90},
+	}
+
+	expectedMatrix := T{
+		vec3.T{10, 40, 70},
+		vec3.T{20, 50, 80},
+		vec3.T{30, 60, 90},
+	}
+
+	transposedMatrix := matrix
+	transposedMatrix.Transpose()
+
+	if transposedMatrix != expectedMatrix {
+		t.Errorf("matrix transposed wrong: %v --> %v", matrix, transposedMatrix)
+	}
+}
+
 func TestDeterminant_2(t *testing.T) {
 	detTwo := Ident
 	detTwo[0][0] = 2
@@ -68,12 +132,12 @@ func TestDeterminant_7(t *testing.T) {
 	if err != nil {
 		t.Errorf("Could not parse random matrix: %v", err)
 	}
-	if det := randomMatrix.Determinant(); practicallyEqual(det, 0.043437) {
+	if det := randomMatrix.Determinant(); PracticallyEquals(det, 0.043437) {
 		t.Errorf("Wrong determinant for random sub 3x3 matrix: %f", det)
 	}
 }
 
-func practicallyEqual(value1 float64, value2 float64) bool {
+func PracticallyEquals(value1 float64, value2 float64) bool {
 	return math.Abs(value1-value2) > EPSILON
 }
 
@@ -101,11 +165,39 @@ func TestMaskedBlock(t *testing.T) {
 
 func TestAdjugate(t *testing.T) {
 	adj := row123Changed
-	adj.Adjugate()
+
 	// Computed in octave:
-	adjExpected := T{vec3.T{23, -4, -0.5}, vec3.T{-12, 20.5, -5}, vec3.T{7, -17, 13}}
+	adjExpected := T{
+		vec3.T{23, -4, -0.5},
+		vec3.T{-12, 20.5, -5},
+		vec3.T{7, -17, 13},
+	}
+
+	adj.Adjugate()
+
 	if adj != adjExpected {
 		t.Errorf("Adjugate not computed correctly: %#v", adj)
+	}
+}
+
+func TestAdjugated(t *testing.T) {
+	sqrt2 := math.Sqrt(2)
+	A := T{
+		vec3.T{1, 0, -1},
+		vec3.T{0, sqrt2, 0},
+		vec3.T{1, 0, 1},
+	}
+
+	expectedAdjugated := T{
+		vec3.T{1.4142135623730951, -0, 1.4142135623730951},
+		vec3.T{-0, 2, -0},
+		vec3.T{-1.4142135623730951, -0, 1.4142135623730951},
+	}
+
+	adjA := A.Adjugated()
+
+	if adjA != expectedAdjugated {
+		t.Errorf("Adjugate not computed correctly: %v", adjA)
 	}
 }
 
@@ -120,6 +212,30 @@ func TestInvert_ok(t *testing.T) {
 	invExpected := invertedMatrix1
 	if inv != invExpected {
 		t.Errorf("Inverse not computed correctly: %#v", inv)
+	}
+}
+
+func TestInvert_ok2(t *testing.T) {
+	sqrt2 := math.Sqrt(2)
+	A := T{
+		vec3.T{1, 0, -1},
+		vec3.T{0, sqrt2, 0},
+		vec3.T{1, 0, 1},
+	}
+
+	expectedInverted := T{
+		vec3.T{0.5, 0, 0.5},
+		vec3.T{0, 0.7071067811865475, 0},
+		vec3.T{-0.5, 0, 0.5},
+	}
+
+	invA, err := A.Inverted()
+	if err != nil {
+		t.Error("Inverse not computed correctly", err)
+	}
+
+	if invA != expectedInverted {
+		t.Errorf("Inverse not computed correctly: %v", A)
 	}
 }
 

--- a/float64/vec2/vec2.go
+++ b/float64/vec2/vec2.go
@@ -98,6 +98,12 @@ func (vec *T) Scaled(f float64) T {
 	return T{vec[0] * f, vec[1] * f}
 }
 
+// PracticallyEquals compares two vectors if they are equal with each other within a delta tolerance.
+func (vec *T) PracticallyEquals(compareVector *T, allowedDelta float64) bool {
+	return (math.Abs(vec[0]-compareVector[0]) <= allowedDelta) &&
+		(math.Abs(vec[1]-compareVector[1]) <= allowedDelta)
+}
+
 // Invert inverts the vector.
 func (vec *T) Invert() *T {
 	vec[0] = -vec[0]

--- a/float64/vec3/vec3.go
+++ b/float64/vec3/vec3.go
@@ -119,6 +119,13 @@ func (vec *T) Scaled(f float64) T {
 	return T{vec[0] * f, vec[1] * f, vec[2] * f}
 }
 
+// PracticallyEquals compares two vectors if they are equal with each other within a delta tolerance.
+func (vec *T) PracticallyEquals(compareVector *T, allowedDelta float64) bool {
+	return (math.Abs(vec[0]-compareVector[0]) <= allowedDelta) &&
+		(math.Abs(vec[1]-compareVector[1]) <= allowedDelta) &&
+		(math.Abs(vec[2]-compareVector[2]) <= allowedDelta)
+}
+
 // Invert inverts the vector.
 func (vec *T) Invert() *T {
 	vec[0] = -vec[0]

--- a/mat2/mat2_test.go
+++ b/mat2/mat2_test.go
@@ -1,0 +1,154 @@
+package mat2
+
+import (
+	"math"
+	"testing"
+
+	"github.com/ungerik/go3d/vec2"
+)
+
+const EPSILON = 0.0001
+
+// Some matrices used in multiple tests.
+var (
+	invertableMatrix1    = T{vec2.T{4, -2}, vec2.T{8, -3}}
+	invertedMatrix1      = T{vec2.T{-3.0 / 4.0, 1.0 / 2.0}, vec2.T{-2, 1}}
+	nonInvertableMatrix1 = T{vec2.T{1, 1}, vec2.T{1, 1}}
+	nonInvertableMatrix2 = T{vec2.T{2, 0}, vec2.T{1, 0}}
+
+	testMatrix1 = T{
+		vec2.T{0.38016528, -0.0661157},
+		vec2.T{-0.19834709, 0.33884296},
+	}
+
+	testMatrix2 = T{
+		vec2.T{23, -4},
+		vec2.T{-12, 20.5},
+	}
+
+	row123Changed, _ = Parse("3 1   2 5")
+)
+
+func TestT_Transposed(t *testing.T) {
+	matrix := T{
+		vec2.T{1, 2},
+		vec2.T{3, 4},
+	}
+	expectedMatrix := T{
+		vec2.T{1, 3},
+		vec2.T{2, 4},
+	}
+
+	transposedMatrix := matrix.Transposed()
+
+	if transposedMatrix != expectedMatrix {
+		t.Errorf("matrix trasnposed wrong: %v --> %v", matrix, transposedMatrix)
+	}
+}
+
+func TestT_Transpose(t *testing.T) {
+	matrix := T{
+		vec2.T{10, 20},
+		vec2.T{30, 40},
+	}
+
+	expectedMatrix := T{
+		vec2.T{10, 30},
+		vec2.T{20, 40},
+	}
+
+	transposedMatrix := matrix
+	transposedMatrix.Transpose()
+
+	if transposedMatrix != expectedMatrix {
+		t.Errorf("matrix transposed wrong: %v --> %v", matrix, transposedMatrix)
+	}
+}
+
+func TestDeterminant_2(t *testing.T) {
+	detTwo := Ident
+	detTwo[0][0] = 2
+	if det := detTwo.Determinant(); det != (2*1 - 0*0) {
+		t.Errorf("Wrong determinant: %f", det)
+	}
+}
+
+func TestDeterminant_3(t *testing.T) {
+	scale2 := Ident.Scaled(2)
+	if det := scale2.Determinant(); det != (2*2 - 0*0) {
+		t.Errorf("Wrong determinant: %f", det)
+	}
+}
+
+func TestDeterminant_4(t *testing.T) {
+	row1changed, _ := Parse("3 0   2 2")
+	if det := row1changed.Determinant(); det != (3*2 - 0*2) {
+		t.Errorf("Wrong determinant: %f", det)
+	}
+}
+
+func TestDeterminant_5(t *testing.T) {
+	row12changed, _ := Parse("3 1   2 5")
+	if det := row12changed.Determinant(); det != (3*5 - 1*2) {
+		t.Errorf("Wrong determinant: %f", det)
+	}
+}
+
+func TestDeterminant_7(t *testing.T) {
+	randomMatrix, err := Parse("0.43685 0.81673   0.16600 0.40608")
+	randomMatrix.Transpose()
+	if err != nil {
+		t.Errorf("Could not parse random matrix: %v", err)
+	}
+	if det := randomMatrix.Determinant(); PracticallyEquals(det, 0.0418189) {
+		t.Errorf("Wrong determinant for random sub 3x3 matrix: %f", det)
+	}
+}
+
+func PracticallyEquals(value1 float32, value2 float32) bool {
+	return math.Abs(float64(value1-value2)) > EPSILON
+}
+
+func TestDeterminant_6(t *testing.T) {
+	row123changed := row123Changed
+	if det := row123changed.Determinant(); det != (3*5 - 2*1) {
+		t.Errorf("Wrong determinant for 3x3 matrix: %f", det)
+	}
+}
+
+func TestDeterminant_1(t *testing.T) {
+	detId := Ident.Determinant()
+	if detId != 1 {
+		t.Errorf("Wrong determinant for identity matrix: %f", detId)
+	}
+}
+
+func TestInvert_ok(t *testing.T) {
+	inv := invertableMatrix1
+	_, err := inv.Invert()
+
+	if err != nil {
+		t.Error("Inverse not computed correctly", err)
+	}
+
+	invExpected := invertedMatrix1
+	if inv != invExpected {
+		t.Errorf("Inverse not computed correctly: %#v", inv)
+	}
+}
+
+func TestInvert_nok_1(t *testing.T) {
+	inv := nonInvertableMatrix1
+	_, err := inv.Inverted()
+	if err == nil {
+		t.Error("Inverse should not be possible", err)
+	}
+}
+
+func TestInvert_nok_2(t *testing.T) {
+	inv := nonInvertableMatrix2
+	_, err := inv.Inverted()
+	if err == nil {
+		t.Error("Inverse should not be possible", err)
+	}
+}

--- a/mat3/mat3_test.go
+++ b/mat3/mat3_test.go
@@ -33,6 +33,70 @@ var (
 	row123Changed, _ = Parse("3 1 0.5   2 5 2   1 6 7")
 )
 
+func Test_ColsAndRows(t *testing.T) {
+	A := testMatrix2
+
+	a11 := A.Get(0, 0)
+	a21 := A.Get(0, 1)
+	a31 := A.Get(0, 2)
+
+	a12 := A.Get(1, 0)
+	a22 := A.Get(1, 1)
+	a32 := A.Get(1, 2)
+
+	a13 := A.Get(2, 0)
+	a23 := A.Get(2, 1)
+	a33 := A.Get(2, 2)
+
+	correctReference := a11 == 23 && a21 == -4 && a31 == -0.5 &&
+		a12 == -12 && a22 == 20.5 && a32 == -5 &&
+		a13 == 7 && a23 == -17 && a33 == 13
+
+	if !correctReference {
+		t.Errorf("matrix ill referenced")
+	}
+}
+
+func TestT_Transposed(t *testing.T) {
+	matrix := T{
+		vec3.T{1, 2, 3},
+		vec3.T{4, 5, 6},
+		vec3.T{7, 8, 9},
+	}
+	expectedMatrix := T{
+		vec3.T{1, 4, 7},
+		vec3.T{2, 5, 8},
+		vec3.T{3, 6, 9},
+	}
+
+	transposedMatrix := matrix.Transposed()
+
+	if transposedMatrix != expectedMatrix {
+		t.Errorf("matrix transposed wrong: %v --> %v", matrix, transposedMatrix)
+	}
+}
+
+func TestT_Transpose(t *testing.T) {
+	matrix := T{
+		vec3.T{10, 20, 30},
+		vec3.T{40, 50, 60},
+		vec3.T{70, 80, 90},
+	}
+
+	expectedMatrix := T{
+		vec3.T{10, 40, 70},
+		vec3.T{20, 50, 80},
+		vec3.T{30, 60, 90},
+	}
+
+	transposedMatrix := matrix
+	transposedMatrix.Transpose()
+
+	if transposedMatrix != expectedMatrix {
+		t.Errorf("matrix transposed wrong: %v --> %v", matrix, transposedMatrix)
+	}
+}
+
 func TestDeterminant_2(t *testing.T) {
 	detTwo := Ident
 	detTwo[0][0] = 2
@@ -68,12 +132,12 @@ func TestDeterminant_7(t *testing.T) {
 	if err != nil {
 		t.Errorf("Could not parse random matrix: %v", err)
 	}
-	if det := randomMatrix.Determinant(); practicallyEqual(det, 0.043437) {
+	if det := randomMatrix.Determinant(); PracticallyEquals(det, 0.043437) {
 		t.Errorf("Wrong determinant for random sub 3x3 matrix: %f", det)
 	}
 }
 
-func practicallyEqual(value1 float32, value2 float32) bool {
+func PracticallyEquals(value1 float32, value2 float32) bool {
 	return math.Abs(float64(value1-value2)) > EPSILON
 }
 
@@ -101,11 +165,39 @@ func TestMaskedBlock(t *testing.T) {
 
 func TestAdjugate(t *testing.T) {
 	adj := row123Changed
-	adj.Adjugate()
+
 	// Computed in octave:
-	adjExpected := T{vec3.T{23, -4, -0.5}, vec3.T{-12, 20.5, -5}, vec3.T{7, -17, 13}}
+	adjExpected := T{
+		vec3.T{23, -4, -0.5},
+		vec3.T{-12, 20.5, -5},
+		vec3.T{7, -17, 13},
+	}
+
+	adj.Adjugate()
+
 	if adj != adjExpected {
 		t.Errorf("Adjugate not computed correctly: %#v", adj)
+	}
+}
+
+func TestAdjugated(t *testing.T) {
+	sqrt2 := float32(math.Sqrt(2))
+	A := T{
+		vec3.T{1, 0, -1},
+		vec3.T{0, sqrt2, 0},
+		vec3.T{1, 0, 1},
+	}
+
+	expectedAdjugated := T{
+		vec3.T{1.4142135623730951, -0, 1.4142135623730951},
+		vec3.T{-0, 2, -0},
+		vec3.T{-1.4142135623730951, -0, 1.4142135623730951},
+	}
+
+	adjA := A.Adjugated()
+
+	if adjA != expectedAdjugated {
+		t.Errorf("Adjugate not computed correctly: %v", adjA)
 	}
 }
 
@@ -120,6 +212,30 @@ func TestInvert_ok(t *testing.T) {
 	invExpected := invertedMatrix1
 	if inv != invExpected {
 		t.Errorf("Inverse not computed correctly: %#v", inv)
+	}
+}
+
+func TestInvert_ok2(t *testing.T) {
+	sqrt2 := float32(math.Sqrt(2))
+	A := T{
+		vec3.T{1, 0, -1},
+		vec3.T{0, sqrt2, 0},
+		vec3.T{1, 0, 1},
+	}
+
+	expectedInverted := T{
+		vec3.T{0.5, 0, 0.5},
+		vec3.T{0, 0.7071067811865475, 0},
+		vec3.T{-0.5, 0, 0.5},
+	}
+
+	invA, err := A.Inverted()
+	if err != nil {
+		t.Error("Inverse not computed correctly", err)
+	}
+
+	if !invA.PracticallyEquals(&expectedInverted, EPSILON) {
+		t.Errorf("Inverse not computed correctly: %v", A)
 	}
 }
 

--- a/vec2/vec2.go
+++ b/vec2/vec2.go
@@ -98,6 +98,12 @@ func (vec *T) Scaled(f float32) T {
 	return T{vec[0] * f, vec[1] * f}
 }
 
+// PracticallyEquals compares two vectors if they are equal with each other within a delta tolerance.
+func (vec *T) PracticallyEquals(compareVector *T, allowedDelta float32) bool {
+	return (math.Abs(vec[0]-compareVector[0]) <= allowedDelta) &&
+		(math.Abs(vec[1]-compareVector[1]) <= allowedDelta)
+}
+
 // Invert inverts the vector.
 func (vec *T) Invert() *T {
 	vec[0] = -vec[0]

--- a/vec3/vec3.go
+++ b/vec3/vec3.go
@@ -120,6 +120,13 @@ func (vec *T) Scaled(f float32) T {
 	return T{vec[0] * f, vec[1] * f, vec[2] * f}
 }
 
+// PracticallyEquals compares two vectors if they are equal with each other within a delta tolerance.
+func (vec *T) PracticallyEquals(compareVector *T, allowedDelta float32) bool {
+	return (math.Abs(vec[0]-compareVector[0]) <= allowedDelta) &&
+		(math.Abs(vec[1]-compareVector[1]) <= allowedDelta) &&
+		(math.Abs(vec[2]-compareVector[2]) <= allowedDelta)
+}
+
 // Invert inverts the vector.
 func (vec *T) Invert() *T {
 	vec[0] = -vec[0]


### PR DESCRIPTION
Add PracticallyEquals (vec2 vec3 mat2 mat3 for both float32 float64) to compare if vectors and matrices are equal within a tolerance threshold.
Add invert to mat2 (float32 float64).
Unroll Mul function (mat3 float32 float64)
Unroll Transpose (mat3 float32 float64)
Unroll Adjugate (mat3 float32 float64)
Fix bug in Invert function (mat3 float32 float64)